### PR TITLE
Support php 8, use `spl_autoload_register`

### DIFF
--- a/DRPC.php
+++ b/DRPC.php
@@ -1,15 +1,15 @@
 <?php
 
-function __autoload($classname) {    
-    
-    $filename = str_replace("\\", "/", "lib/".$classname . ".php");
-	
-	$filename =  dirname(__FILE__)."/".$filename;
-    if(file_exists( $filename )) {	
-		require_once($filename);
+spl_autoload_register(
+    function ($classname) {
+        $filename = str_replace("\\", "/", "lib/" . $classname . ".php");
+
+        $filename =  dirname(__FILE__) . "/" . $filename;
+        if (file_exists($filename)) {
+            require_once($filename);
+        }
     }
-    
-}
+);
 
 include_once(dirname(__FILE__)."/lib/DistributedRPC.php");
 


### PR DESCRIPTION
Replaces the deprecated `__autoload` function with `spl_autoload_register` to support usage with php >=8.

Fixes #4.