### PR TITLE
fix: Check socket connection before using

### DIFF
--- a/lib/Thrift/Transport/TSocket.php
+++ b/lib/Thrift/Transport/TSocket.php
@@ -226,9 +226,6 @@ class TSocket extends TTransport {
                                   $this->sendTimeoutSec_ + ($this->sendTimeoutUsec_ / 1000000));
     }
 	
-	//timeout fix for thrift
-	stream_set_blocking($this->handle_,0);
-	
     // Connect failed?
     if ($this->handle_ === FALSE) {
       $error = 'TSocket: Could not connect to '.$this->host_.':'.$this->port_.' ('.$errstr.' ['.$errno.'])';
@@ -237,6 +234,9 @@ class TSocket extends TTransport {
       }
       throw new TException($error);
     }
+
+    //timeout fix for thrift
+    stream_set_blocking($this->handle_,0);
   }
 
   /**


### PR DESCRIPTION
PHP 8 throws a TypeError instead of a warning when the expected type/value is wrong. This fix makes sure to check that the socket connection actually succeeded before trying to pass it to `stream_set_blocking`.

Fixes the following TypeError:
```
PHP message: PHP Fatal error:  Uncaught TypeError: stream_set_blocking(): Argument #1 ($stream) must be of type resource, bool given in /usr/share/php/php-drpc/lib/Thrift/Transport/TSocket.php:230 Stack trace:
/usr/share/php/php-drpc/lib/Thrift/Transport/TSocket.php(230): stream_set_blocking(false, 0)
/usr/share/php/php-drpc/lib/Thrift/Transport/TFramedTransport.php(87): Thrift\Transport\TSocket->open()
/usr/share/php/php-drpc/DRPC.php(69): Thrift\Transport\TFramedTransport->open()
```